### PR TITLE
Added rol20 template cards

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,4 +1,0 @@
-module.exports = {
-  presets: ["@babel/preset-env"],
-  plugins: ["@babel/plugin-transform-runtime"],
-};

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ typings/
 # Parcel related files
 dist/
 .cache/
+.parcel-cache/
 
 # Editor configuration
 .vscode/

--- a/config.html
+++ b/config.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+  </head>
+  <body>
+    
+    <input type ="text" id="discordurl" name="discordurl" value="Webookurl">
+   
+    <div id="status"></div>
+<button id="save">Save</button>
+
+  </body>
+<script src="config.js"></script>
+  </html>

--- a/config.js
+++ b/config.js
@@ -1,0 +1,30 @@
+// Saves options to chrome.storage
+function save_options() {
+    var discordurl = document.getElementById('discordurl').value;
+    chrome.storage.sync.set({
+      discordurl: discordurl
+    }, function() {
+      // Update status to let user know options were saved.
+      var status = document.getElementById('status');
+      console.debug('Saved as: ' + discordurl);
+      status.textContent = 'Options saved.';
+      setTimeout(function() {
+        status.textContent = '';
+      }, 750);
+    });
+  }
+  
+  // Restores select box and checkbox state using the preferences
+  // stored in chrome.storage.
+  function restore_options() {
+    chrome.storage.sync.get({
+        discordurl: ''
+    }, function(items) {
+      document.getElementById('discordurl').value = items.discordurl;
+      console.debug('Loaded: ' + discordurl);
+    });
+  }
+
+
+  document.addEventListener('DOMContentLoaded', restore_options);
+  document.getElementById('save').addEventListener('click',save_options);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "VTT Bridge",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Connect Dungeon Master's Vault to Roll20.",
   "icons": {
     "48": "icons/48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,19 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "VTT Bridge",
   "version": "1.6.3",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "addon@example.com"
+    }
+  },
   "description": "Connect Dungeon Master's Vault to Roll20.",
+ 
+
+  "background": {
+    "service_worker": "wrapper.js",
+    "type": "module"
+  },
   "icons": {
     "48": "icons/48.png",
     "96": "icons/96.png",
@@ -19,8 +30,6 @@
       "js": ["dist/polyfill.js", "dist/roll20.js"],
       "css": ["dist/roll20.css"]
     }
-  ],
-  "background": {
-    "scripts": ["dist/polyfill.js", "dist/background.js"]
-  }
+  ]
+  
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,16 @@
     "96": "icons/96.png",
     "128": "icons/128.png"
   },
+  "permissions": [
+    "storage"
+  ],
+  "options_ui": {
+    "page": "config.html",
+    "open_in_tab": false
+  },
+    "browser_action": {
+      "default_popup": "config.html"
+    },
   "content_scripts": [
     {
       "matches": ["*://www.dungeonmastersvault.com/pages/dnd/5e/characters/*?frame=true"],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vtt-bridge",
   "description": "Connect Dungeon Master's Vault to Roll20.",
   "author": "Avery Crespi",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "MIT",
   "dependencies": {
     "beedle": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -6,28 +6,30 @@
   "license": "MIT",
   "dependencies": {
     "beedle": "^0.8.1",
-    "notyf": "^3.6.0"
+    "node": "^19.4.0",
+    "notyf": "^3.10.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.9.6",
-    "@babel/plugin-transform-runtime": "^7.9.6",
-    "@babel/preset-env": "^7.9.6",
-    "babel-jest": "^26.0.1",
-    "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.1",
-    "eslint-plugin-jest": "^23.9.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "jest": "^26.0.1",
-    "parcel-bundler": "^1.12.4",
-    "prettier": "^2.0.2",
-    "web-ext": "^4.2.0",
-    "webextension-polyfill": "^0.6.0"
+    "@babel/core": "^7.20.12",
+    "@babel/plugin-transform-runtime": "^7.19.6",
+    "@babel/preset-env": "^7.20.2",
+    "babel-jest": "^29.4.0",
+    "eslint": "^8.32.0",
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-jest": "^27.2.1",
+    "eslint-plugin-prettier": "^4.2.1",
+    "jest": "^29.4.0",
+    "parcel": "^2.8.3",
+    "prettier": "^2.8.3",
+    "web-ext": "^7.5.0",
+    "webextension-polyfill": "^0.10.0",
+    "yarn-upgrade-all": "^0.7.2"
   },
   "scripts": {
     "parcel:polyfill": "mkdir -p dist/ && cp node_modules/webextension-polyfill/dist/browser-polyfill.min.js dist/polyfill.js",
     "parcel:build": "yarn parcel:polyfill && parcel build --no-source-maps src/scripts/*",
     "parcel:watch": "yarn parcel:polyfill && parcel watch --no-source-maps src/scripts/*",
-    "parcel:clean": "rm -rf dist/*",
+    "parcel:clean": "rm -rf disty/*",
     "parcel:rebuild": "yarn parcel:clean && yarn parcel:build",
     "parcel:test": "jest",
     "assets:optimize": "optipng assets/*",
@@ -55,7 +57,10 @@
       "keepProfileChanges": true,
       "firefoxProfile": ".profiles/firefox",
       "chromiumProfile": ".profiles/chromium",
-      "watchFile": "dist/dmv.js",
+      "watchFile": [
+        "dist/dmv.js",
+        ""
+      ],
       "startUrl": [
         "https://www.dungeonmastersvault.com/pages/dnd/5e/characters",
         "https://app.roll20.net"

--- a/src/dispatch/expandSpell.js
+++ b/src/dispatch/expandSpell.js
@@ -27,6 +27,23 @@ const ready = (store) => {
         }
 
         const cell = button.closest("td");
+        
+        //Get spell details as array
+        const div = Array.from(cell.querySelectorAll("div"));
+        const spellItems = (div[0].innerText).split("\n");
+
+        const index = spellItems.indexOf("CAST SPELL");//Rip out all the different cast levels
+        spellItems.splice(0,index +1);
+
+       
+        console.debug(`Added expand spell items: ${spellItems}`);
+
+        /*const school = items[3];
+        const castingTime = items[4];
+        const range = items[5];
+        const duration = items[6];
+        const components = items[7];
+        */
         const paragraphs = Array.from(cell.querySelectorAll("p"));
         const description = paragraphs.map((p) => p.innerText).join("\n");
         if (!isValidDescription(description)) {
@@ -35,7 +52,7 @@ const ready = (store) => {
         }
 
         button.addEventListener("click", function (event) {
-          store.dispatch(STORE_CLICK, { className, event, data: { name, description } });
+          store.dispatch(STORE_CLICK, { className, event, data: { name, description, spellItems } });
         });
 
         console.debug(`Added expand spell listener: ${name}`);

--- a/src/dispatch/weapon.js
+++ b/src/dispatch/weapon.js
@@ -30,11 +30,8 @@ const ready = (store) => {
     }
 
     attackButton.classList.add(classes.attackWithWeapon);
-    attackButton.addEventListener("click", function (event) {
-      store.dispatch(STORE_CLICK, { className: classes.attackWithWeapon, event, data: { name, attack } });
-    });
-    console.debug(`Added weapon attack listener: ${name}`);
-
+    
+    
     for (const damageButton of damageButtons) {
       let damage = damageButton.innerText;
       if (damage.charAt(0) === "v") {
@@ -47,6 +44,14 @@ const ready = (store) => {
       }
 
       damageButton.classList.add(classes.rollWeaponDamage);
+
+      
+      attackButton.addEventListener("click", function (event) {
+        store.dispatch(STORE_CLICK, { className: classes.attackWithWeapon, event, data: { name, attack, damage } });
+      });
+
+      console.debug(`Added weapon attack listener: ${name}`);
+
       damageButton.addEventListener("click", function (event) {
         store.dispatch(STORE_CLICK, { className: classes.rollWeaponDamage, event, data: { name, damage } });
       });

--- a/src/scripts/discord.js
+++ b/src/scripts/discord.js
@@ -1,14 +1,20 @@
 export function sendMessage(message) {
-    const request = new XMLHttpRequest();
-    request.open("POST", "DISCORD WEBOOK URL GOES HERE");
+  chrome.storage.sync.get("discordurl", function (items) {
+    if (!chrome.runtime.error) {
+      console.debug('Loaded: URL as' + items.discordurl);
 
-    request.setRequestHeader('Content-type', 'application/json');
+      const request = new XMLHttpRequest();
+      request.open("POST", items.discordurl);
 
-    const params = {
-      username: "DMZ-Bot",
-      avatar_url: "",
-      content: message
+      request.setRequestHeader('Content-type', 'application/json');
+
+      const params = {
+        username: "DMZ-Bot",
+        avatar_url: "",
+        content: message
+      }
+
+      request.send(JSON.stringify(params));
     }
-
-    request.send(JSON.stringify(params));
-  }
+  });
+}

--- a/src/scripts/discord.js
+++ b/src/scripts/discord.js
@@ -1,0 +1,14 @@
+export function sendMessage(message) {
+    const request = new XMLHttpRequest();
+    request.open("POST", "DISCORD WEBOOK URL GOES HERE");
+
+    request.setRequestHeader('Content-type', 'application/json');
+
+    const params = {
+      username: "DMZ-Bot",
+      avatar_url: "",
+      content: message
+    }
+
+    request.send(JSON.stringify(params));
+  }

--- a/src/scripts/discord.js
+++ b/src/scripts/discord.js
@@ -2,7 +2,7 @@ export function sendMessage(message) {
   chrome.storage.sync.get("discordurl", function (items) {
     if (!chrome.runtime.error) {
       console.debug('Loaded: URL as' + items.discordurl);
-
+      const character = document.querySelector(".character-name").innerText
       const request = new XMLHttpRequest();
       request.open("POST", items.discordurl);
 
@@ -10,8 +10,15 @@ export function sendMessage(message) {
 
       const params = {
         username: "DMZ-Bot",
-        avatar_url: "",
-        content: message
+        avatar_url: "https://github.com/Garemat/vtt-bridge/blob/main/icons/128.png?raw=true",
+        content: null, 
+        embeds: [
+          {
+          title: character, 
+          description: character + " has made a " + message
+        }
+        ]
+        
       }
 
       request.send(JSON.stringify(params));

--- a/src/scripts/dmv.js
+++ b/src/scripts/dmv.js
@@ -5,6 +5,7 @@ import { createStore } from "../store";
 import { formatError } from "../transform/error";
 import { messageType } from "../common";
 import { parseState } from "../transform/state";
+import { sendMessage } from "./discord";
 
 const store = createStore();
 addDispatchers(store, () => showConnected());
@@ -28,3 +29,44 @@ store.subscribe((state) => {
     console.debug(`Showed visibility toast: ${JSON.stringify(state.visible)}`);
   }
 });
+
+function waitForElm(selector) {
+  return new Promise(resolve => {
+      if (document.querySelector(selector)) {
+          return resolve(document.querySelector(selector));
+      }
+
+      const observer = new MutationObserver(mutations => {
+          if (document.querySelector(selector)) {
+              resolve(document.querySelector(selector));
+              observer.disconnect();
+          }
+      });
+
+      observer.observe(document.body, {
+          childList: true,
+          subtree: true
+      });
+  });
+}
+
+waitForElm('.bg-green').then((elm) => {
+  console.log('Element is ready');
+  console.log(elm.textContent);
+  var mutationObserver = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+      console.log(mutation.target.textContent);
+      sendMessage(mutation.target.textContent)
+    });
+  });
+  mutationObserver.observe(document.querySelector('.bg-green'), {
+    attributes: true,
+    characterData: true,
+    childList: true,
+    subtree: true,
+    attributeOldValue: true,
+    characterDataOldValue: true
+  });
+  
+});
+

--- a/src/transform/commands.js
+++ b/src/transform/commands.js
@@ -85,3 +85,12 @@ export const makeSpellAttack = (attack, { hasAdvantage, hasDisadvantage, visible
     return prefix + attack;
   }
 };
+
+export const makeTrait = (description, character, name, { visible }) => {
+  const prefix = visible ? "" : "/w gm ";
+
+  return prefix + "&{template:traits} {{charname="+ character +"}} {{name="+ name + "}} {{source=Features}} {{description="+description.replace(/\n/g, "\n")+"}}"
+};
+
+
+

--- a/src/transform/commands.js
+++ b/src/transform/commands.js
@@ -1,4 +1,4 @@
-export const makeD20Roll = (mod, character, name,{ hasAdvantage, hasDisadvantage, visible }) => {
+export const makeD20Roll = (mod, character, name, { hasAdvantage, hasDisadvantage, visible }) => {
   const prefix = visible ? "" : "/w gm ";
   const suffix = mod === "0" ? "" : mod;
   let rollType = ""
@@ -10,7 +10,7 @@ export const makeD20Roll = (mod, character, name,{ hasAdvantage, hasDisadvantage
     rollType = "always"
   }
 
-  return prefix + "&{template:simple} {{charname="+ character+"}} {{rname="+name+"}} {{mod="+mod+"}} {{r1=[[1d20"+mod+"]]}} {{"+rollType+"=1}} {{r2=[[1d20"+mod+"]]}}"
+  return prefix + "&{template:simple} {{charname=" + character + "}} {{rname=" + name + "}} {{mod=" + mod + "}} {{r1=[[1d20" + mod + "]]}} {{" + rollType + "=1}} {{r2=[[1d20" + mod + "]]}}"
 };
 
 export const makeDamageRoll = (damage, { visible }) => {
@@ -18,9 +18,35 @@ export const makeDamageRoll = (damage, { visible }) => {
   return prefix + damage;
 };
 
-export const makeDescription = (description, { visible }) => {
+export const makeDescription = (description, character, spellName, spellItems, { visible }) => {
   const prefix = visible ? "" : "/w gm ";
-  return prefix + description.replace(/\n/g, "\n" + prefix);
+  const descriptionBlock = spellItems[4];
+  let components = "";
+  let materials = "";
+
+  //Split out the casting components and material components of spell description
+  //As of writing this there are NO spells with only material components, RAW requires an open hand to handle material components, so will always be at least S,M, so didn't write logic to handle only material componets
+
+  if (descriptionBlock.length > 15) { //If the spell card contains material components
+    components = descriptionBlock.substr(11, descriptionBlock.length).split(",")
+    const materialsArray = components[components.length - 1].split(" ");
+    components.splice(-1);
+    components.push(materialsArray[1])
+    materialsArray.splice(1, 1);
+    materials = materialsArray.join(" ").slice(2,-1); //The slice is to remove the first and last bracket since roll20 template adds them in
+  } else if (descriptionBlock.length > 12) { // Is just V,S
+    components = descriptionBlock.substr(11, 15)
+  } else { //Only V or S
+    components = descriptionBlock.substr(11, 12)
+  }
+
+  //Work out if the spell as VSM for template 
+  const verbal = (components.includes("V") || components.includes(" V")) ? "1" : "0";
+  const somatic = (components.includes("S") || components.includes(" S") ) ? "1" : "0";
+  const material = (components.includes("M") || components.includes(" M")) ? "1" : "0";
+
+
+  return prefix + "&{template:spell} {{charname=" + character + "}} {{name=" + spellName + "}} {{castingtime=" + spellItems[1].substr(13, spellItems[1].length) + "}} {{range=" + spellItems[2] + "}} {{duration=" + spellItems[3] + "}} {{level=" + spellItems[0] + "}} {{v="+verbal+ "}} {{s="+somatic+ "}} {{m="+material+ "}} {{material=" + materials + "}} {{description=" + description.replace(/\n/g, "\n") + "}}"
 };
 
 export const makeEmote = (text, { hasAdvantage, hasDisadvantage, visible }) => {
@@ -48,5 +74,14 @@ export const makeWeaponAttack = (attack, character, wepName, damage, { hasAdvant
     rollType = "always"
   }
 
-  return prefix + "&{template:atkdmg} {{charname="+character+"}} {{rname="+wepName+"}} {{mod=+"+diceRoll[1]+"}} {{r1=[[1d20 +"+diceRoll[1]+"]]}} {{attack=1}} {{damage=1}} {{dmg1flag=1}} {{dmg1=[["+damage+"]]}} {{dmg1type=Piercing}} {{crit1=Crit: [[1d4]]}} {{"+rollType+"=1}} {{r2=[[1d20 +"+diceRoll[1]+"]]}}";
+  return prefix + "&{template:atkdmg} {{charname=" + character + "}} {{rname=" + wepName + "}} {{mod=+" + diceRoll[1] + "}} {{r1=[[1d20 +" + diceRoll[1] + "]]}} {{attack=1}} {{damage=1}} {{dmg1flag=1}} {{dmg1=[[" + damage + "]]}} {{dmg1type=Piercing}} {{crit1=Crit: [[1d4]]}} {{" + rollType + "=1}} {{r2=[[1d20 +" + diceRoll[1] + "]]}}";
+};
+
+export const makeSpellAttack = (attack, { hasAdvantage, hasDisadvantage, visible }) => {
+  const prefix = visible ? "/roll " : "/gmroll ";
+  if (hasAdvantage || hasDisadvantage) {
+    return prefix + attack + "\n" + prefix + attack;
+  } else {
+    return prefix + attack;
+  }
 };

--- a/src/transform/commands.js
+++ b/src/transform/commands.js
@@ -1,13 +1,16 @@
-export const makeD20Roll = (mod, { hasAdvantage, hasDisadvantage, visible }) => {
-  const prefix = visible ? "/roll " : "/gmroll ";
+export const makeD20Roll = (mod, character, name,{ hasAdvantage, hasDisadvantage, visible }) => {
+  const prefix = visible ? "" : "/w gm ";
   const suffix = mod === "0" ? "" : mod;
+  let rollType = ""
   if (hasAdvantage) {
-    return prefix + "2d20kh1" + suffix;
+    rollType = "advantage";
   } else if (hasDisadvantage) {
-    return prefix + "2d20kl1" + suffix;
+    rollType = "disadvantage"
   } else {
-    return prefix + "1d20" + suffix;
+    rollType = "always"
   }
+
+  return prefix + "&{template:simple} {{charname="+ character+"}} {{rname="+name+"}} {{mod="+mod+"}} {{r1=[[1d20"+mod+"]]}} {{"+rollType+"=1}} {{r2=[[1d20"+mod+"]]}}"
 };
 
 export const makeDamageRoll = (damage, { visible }) => {
@@ -31,11 +34,19 @@ export const makeEmote = (text, { hasAdvantage, hasDisadvantage, visible }) => {
   }
 };
 
-export const makeWeaponAttack = (attack, { hasAdvantage, hasDisadvantage, visible }) => {
-  const prefix = visible ? "/roll " : "/gmroll ";
-  if (hasAdvantage || hasDisadvantage) {
-    return prefix + attack + "\n" + prefix + attack;
+export const makeWeaponAttack = (attack, character, wepName, damage, { hasAdvantage, hasDisadvantage, visible }) => {
+  let rollType = ""
+  const prefix = visible ? "" : "/w gm ";
+  const diceRoll = attack.split("+") //1d20 : mod
+  if (hasAdvantage) {
+    rollType = "advantage";
+    //return prefix + "2d20kh1+" + diceRoll[1];
+  } else if (hasDisadvantage) {
+    rollType = "disadvantage"
+    //return prefix + "2d20kl1+" + diceRoll[1];
   } else {
-    return prefix + attack;
+    rollType = "always"
   }
+
+  return prefix + "&{template:atkdmg} {{charname="+character+"}} {{rname="+wepName+"}} {{mod=+"+diceRoll[1]+"}} {{r1=[[1d20 +"+diceRoll[1]+"]]}} {{attack=1}} {{damage=1}} {{dmg1flag=1}} {{dmg1=[["+damage+"]]}} {{dmg1type=Piercing}} {{crit1=Crit: [[1d4]]}} {{"+rollType+"=1}} {{r2=[[1d20 +"+diceRoll[1]+"]]}}";
 };

--- a/src/transform/state.js
+++ b/src/transform/state.js
@@ -1,4 +1,4 @@
-import { makeD20Roll, makeDamageRoll, makeDescription, makeEmote, makeWeaponAttack, makeSpellAttack } from "./commands";
+import { makeD20Roll, makeDamageRoll, makeDescription, makeEmote, makeWeaponAttack, makeSpellAttack , makeTrait} from "./commands";
 
 import { classes } from "../common";
 import { makeToast } from "./toasts";
@@ -61,7 +61,7 @@ export const parseState = (state) => {
     case classes.useFeature:
       return {
         toast: makeToast(`${character} used ${name}`, options),
-        commands: [makeEmote(`${character} uses ${name}`, options), makeDescription(description, options)],
+        commands: [makeEmote(`${character} uses ${name}`, options), makeTrait(description, character, name, options)],
       };
     default:
       throw `Unknown class name: ${className}`;

--- a/src/transform/state.js
+++ b/src/transform/state.js
@@ -18,7 +18,7 @@ export const parseState = (state) => {
     case classes.attackWithWeapon:
       return {
         toast: makeToast(`${character} attacked with ${name}`, options),
-        commands: [makeEmote(`${character} attacks with ${name}`, options), makeWeaponAttack(attack, options)],
+        commands: [makeEmote(`${character} attacks with ${name}`, options), makeWeaponAttack(attack, character, name, damage, options)],
       };
     case classes.castSpell:
       return {
@@ -29,23 +29,23 @@ export const parseState = (state) => {
     case classes.rollSkill:
       return {
         toast: makeToast(`${character} rolled ${name} check`, options),
-        commands: [makeEmote(`${character} rolls ${name} check`, options), makeD20Roll(mod, options)],
+        commands: [makeEmote(`${character} rolls ${name} check`, options), makeD20Roll(mod, character, name, options)],
       };
     case classes.rollInitiative:
       return {
         toast: makeToast(`${character} rolled ${name}`, options),
         // Add turn tracker support to initiative rolls.
-        commands: [makeEmote(`${character} rolls ${name}`, options), makeD20Roll(mod, options) + " &{tracker}"],
+        commands: [makeEmote(`${character} rolls ${name}`, options), makeD20Roll(mod, character, name, options) + " &{tracker}"],
       };
     case classes.rollProficiency:
       return {
         toast: makeToast(`${character} rolled ${name}`, options),
-        commands: [makeEmote(`${character} rolls ${name}`, options), makeD20Roll(mod, options)],
+        commands: [makeEmote(`${character} rolls ${name}`, options), makeD20Roll(mod, character, name, options)],
       };
     case classes.rollSavingThrow:
       return {
         toast: makeToast(`${character} rolled ${name} save`, options),
-        commands: [makeEmote(`${character} rolls ${name} save`, options), makeD20Roll(mod, options)],
+        commands: [makeEmote(`${character} rolls ${name} save`, options), makeD20Roll(mod, character, name, options)],
       };
     case classes.rollWeaponDamage:
       return {

--- a/src/transform/state.js
+++ b/src/transform/state.js
@@ -1,4 +1,4 @@
-import { makeD20Roll, makeDamageRoll, makeDescription, makeEmote, makeWeaponAttack } from "./commands";
+import { makeD20Roll, makeDamageRoll, makeDescription, makeEmote, makeWeaponAttack, makeSpellAttack } from "./commands";
 
 import { classes } from "../common";
 import { makeToast } from "./toasts";
@@ -6,7 +6,7 @@ import { makeToast } from "./toasts";
 export const parseState = (state) => {
   const { click, visible, character } = state;
   const { className, event, data } = click;
-  const { name, mod, description, attack, damage } = data;
+  const { name, mod, description, attack, damage, spellItems } = data;
   const options = {
     hasAdvantage: event && event.ctrlKey,
     hasDisadvantage: event && event.shiftKey,
@@ -14,16 +14,22 @@ export const parseState = (state) => {
   };
 
   switch (className) {
-    case classes.attackWithSpell:
+   
     case classes.attackWithWeapon:
       return {
         toast: makeToast(`${character} attacked with ${name}`, options),
         commands: [makeEmote(`${character} attacks with ${name}`, options), makeWeaponAttack(attack, character, name, damage, options)],
       };
+      case classes.attackWithSpell:
+      return {
+          toast: makeToast(`${character} attacked with ${name}`, options),
+          commands: [makeEmote(`${character} attacks with ${name}`, options), makeSpellAttack(attack, options)],
+      };
     case classes.castSpell:
       return {
         toast: makeToast(`${character} cast ${name}`, options),
-        commands: [makeEmote(`${character} casts ${name}`, options), makeDescription(description, options)],
+        commands: [makeEmote(`${character} casts ${name}`, options), makeDescription(description, character, name, spellItems, options)],
+
       };
     case classes.rollAbilityScore:
     case classes.rollSkill:

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,0 +1,5 @@
+try {
+    importScripts("dist/polyfill.js", "dist/background.js")
+} catch(e) {
+    console.log(e)
+}


### PR DESCRIPTION
All templates are using the 'simple' template offered by roll20, the default template used for the 5e character sheet

Weapon attack + damage has been merged into a single roll (Not sure with preference on this, can look at creating a toggle button though if this isn't wanted) and will display as a formatted template card 

Spell description will output as a formatted card, spell attacks are still a normal roll since it's just a 1d20 + mod + prof bonus

Features will output as a formatted card, DMV doesn't offer the source of the feature as far as I can tell, so the source for all cards is just 'feature'